### PR TITLE
install fuse3 in flake fdietze 2024 05 17

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -141,7 +141,6 @@ docker-image:
   # starting the application is defined in litefs.yml
   # test locally without litefs:
   # docker run -e SESSION_SECRET -e INTERNAL_COMMAND_TOKEN -e HONEYPOT_SECRET sha256:xyzxyz bash /app/startup.sh
-  RUN nix profile install nixpkgs/ba733f8000925e837e30765f273fec153426403d#fuse3
   CMD ["/usr/local/bin/litefs", "mount"]
   SAVE IMAGE jabble:latest
 

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
                 julia_19-bin
                 nodejs_20
                 sqlite
+                fuse3 # for litefs
             ];
           };
           juliabuild = pkgs.buildEnv {


### PR DESCRIPTION
- **Integrate globalbrain-node node extension for calling GlobalBrain.jl from javascript (#43)**
- **fix litefs path**
- **earthly 0.8.10 for all jobs (#65)**
- **install fuse3, quickfix**
- **install fuse3 in flake**
