### PR TITLE
Discussion of the day as frontpage

### DIFF
--- a/app/components/ui/info-text.tsx
+++ b/app/components/ui/info-text.tsx
@@ -14,10 +14,13 @@ Use [this feedback form](https://forms.gle/dzJtsTJwPSsBihPUA) or submit a [GitHu
 	`
 
 	return (
-		<div className={"text-sm border-dashed border-2 border-gray-500 p-4 rounded-xl mb-4 " + (className ?? "")}>
+		<div
+			className={
+				'mb-4 rounded-xl border-2 border-dashed border-gray-500 p-4 text-sm ' +
+				(className ?? '')
+			}
+		>
 			<Markdown deactivateLinks={false}>{infoText}</Markdown>
 		</div>
 	)
 }
-
-

--- a/app/components/ui/info-text.tsx
+++ b/app/components/ui/info-text.tsx
@@ -1,0 +1,23 @@
+import { Markdown } from '#app/components/markdown.tsx'
+
+export default function InfoText({ className }: { className?: string }) {
+	const infoText = `
+### Hey, you are part of our early experiments! 🚀
+
+This platform ranks content not only by how many votes it received, but
+according to **how convincing** it is
+([learn more](https://github.com/social-protocols/social-network#readme)).
+Everything you see here is work in progress.
+We would love to hear your feedback!
+
+Use [this feedback form](https://forms.gle/dzJtsTJwPSsBihPUA) or submit a [GitHub issue](https://github.com/social-protocols/jabble/issues).
+	`
+
+	return (
+		<div className={"text-sm border-dashed border-2 border-gray-500 p-4 rounded-xl mb-4 " + (className ?? "")}>
+			<Markdown deactivateLinks={false}>{infoText}</Markdown>
+		</div>
+	)
+}
+
+

--- a/app/components/ui/post-action-bar.tsx
+++ b/app/components/ui/post-action-bar.tsx
@@ -47,6 +47,19 @@ export function PostActionBar({
 		setCommentTreeState(newCommentTreeState)
 	}
 
+	async function handleSetDiscussionOfTheDay() {
+		const payload = {
+			postId: post.id,
+		}
+		await fetch('/promoteDiscussionOfTheDay', {
+			method: 'POST',
+			body: JSON.stringify(payload),
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		})
+	}
+
 	return (
 		<>
 			<div className="mt-1 flex w-full text-sm">
@@ -64,12 +77,24 @@ export function PostActionBar({
 				)}
 				{isAdminUser &&
 					(!isDeleted ? (
-						<button onClick={() => handleSetDeletedAt(Date.now())}>
+						<button
+							className="mr-2"
+							onClick={() => handleSetDeletedAt(Date.now())}
+						>
 							Delete
 						</button>
 					) : (
 						<button onClick={() => handleSetDeletedAt(null)}>Restore</button>
 					))}
+				{isAdminUser && (
+					<button
+						className="mr-2"
+						title="Promote the root post of this discussion to discussion of the day"
+						onClick={handleSetDiscussionOfTheDay}
+					>
+						Promote
+					</button>
+				)}
 				{showReplyForm && (
 					<button
 						className="ml-auto pr-2"

--- a/app/repositories/post.ts
+++ b/app/repositories/post.ts
@@ -272,3 +272,33 @@ export async function getRootPostId(
 	)?.parentId
 	return parentId == null ? postId : await getRootPostId(trx, parentId)
 }
+
+export async function setDiscussionOfTheDay(
+	trx: Transaction<DB>,
+	postId: number,
+	userId: string,
+) {
+	checkIsAdminOrThrow(userId)
+	const rootPostId = await getRootPostId(trx, postId)
+	await trx
+		.insertInto('DiscussionOfTheDay')
+		.values({
+			postId: rootPostId,
+			promotedAt: Date.now(),
+		})
+		.returningAll()
+		.execute()
+}
+
+export async function getDiscussionOfTheDay(
+	trx: Transaction<DB>,
+): Promise<number | undefined> {
+	const discussionOfTheDayPostId: number | undefined = (
+		await trx
+			.selectFrom('DiscussionOfTheDay')
+			.orderBy('promotedAt', 'desc')
+			.selectAll()
+			.executeTakeFirst()
+	)?.postId
+	return discussionOfTheDayPostId
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -306,7 +306,10 @@ function UserDropdown() {
 						</Form>
 					</DropdownMenuItem>
 					<DropdownMenuItem>
-						<Link to={'/activities/myVotes'}>My Votes</Link>
+						<Link to={'/explore'}>👀 Explore</Link>
+					</DropdownMenuItem>
+					<DropdownMenuItem>
+						<Link to={'/activities/myVotes'}>🔎 Review</Link>
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenuPortal>

--- a/app/routes/explore.tsx
+++ b/app/routes/explore.tsx
@@ -1,0 +1,122 @@
+import { type LoaderFunctionArgs } from '@remix-run/node'
+import { Link, useLoaderData } from '@remix-run/react'
+import moment from 'moment'
+import { useState } from 'react'
+import { Markdown } from '#app/components/markdown.tsx'
+import { Button } from '#app/components/ui/button.tsx'
+import { PostContent } from '#app/components/ui/post-content.tsx'
+import { PostForm } from '#app/components/ui/post-form.tsx'
+import { db } from '#app/db.ts'
+import * as rankingTs from '#app/repositories/ranking.ts'
+import { type FrontPagePost } from '#app/types/api-types.ts'
+import { getUserId } from '#app/utils/auth.server.ts'
+
+export async function loader({ request }: LoaderFunctionArgs) {
+	const userId: string | null = await getUserId(request)
+	const loggedIn = userId !== null
+	const feed = await db.transaction().execute(async trx => {
+		return await rankingTs.getChronologicalToplevelPosts(trx)
+	})
+	return { loggedIn, feed }
+}
+
+export default function Explore() {
+	// due to the loader, this component will never be rendered, but we'll return
+	// the error boundary just in case.
+	let data = useLoaderData<typeof loader>()
+
+	return <FrontpageFeed feed={data.feed} loggedIn={data.loggedIn} />
+}
+
+export function FrontpageFeed({
+	feed,
+	loggedIn,
+}: {
+	feed: FrontPagePost[]
+	loggedIn: boolean
+}) {
+	const [showNewDiscussionForm, setShowNewDiscussionForm] = useState(false)
+
+	const infoText = `
+# Welcome to Jabble
+
+Jabble is a new kind of conversation platform, designed to make conversations on the Internet more intelligent and less polarized.
+
+Read [how Jabble makes conversations better](https://github.com/social-protocols/social-network#readme) and [signup here to get notified when we launch](https://social-protocols.org/social-network/).
+	`
+
+	return (
+		<div className="container">
+			<div className="markdown mb-10">
+				<Markdown deactivateLinks={false}>{infoText}</Markdown>
+			</div>
+
+			{showNewDiscussionForm ? (
+				<PostForm className="mb-4" />
+			) : (
+				loggedIn && (
+					<div className="mb-4 flex justify-end">{newDiscussionButton()}</div>
+				)
+			)}
+
+			<div className="mx-auto w-full">
+				<PostList feed={feed} />
+			</div>
+		</div>
+	)
+
+	function newDiscussionButton() {
+		return (
+			<Button
+				variant="default"
+				onClick={() => {
+					setShowNewDiscussionForm(!showNewDiscussionForm)
+					return false
+				}}
+			>
+				New Discussion
+			</Button>
+		)
+	}
+}
+
+function PostList({ feed }: { feed: FrontPagePost[] }) {
+	const filteredFeed = feed.filter(post => !post.isPrivate)
+	return filteredFeed.map(post => {
+		return <TopLevelPost key={post.id} post={post} className="flex-1" />
+	})
+}
+
+export function TopLevelPost({
+	post,
+	className,
+}: {
+	post: FrontPagePost
+	className?: string
+}) {
+	const ageString = moment(post.createdAt).fromNow()
+	const commentString = post.nTransitiveComments == 1 ? 'comment' : 'comments'
+	const voteString = post.oSize == 1 ? 'vote' : 'votes'
+
+	return (
+		<div
+			className={
+				'postteaser mb-6 flex w-full min-w-0 flex-col ' + (className || '')
+			}
+		>
+			<div className="mb-2 text-sm opacity-50">{ageString}</div>
+			<PostContent
+				content={post.content}
+				maxLines={3}
+				deactivateLinks={false}
+				linkTo={`/post/${post.id}`}
+			/>
+			<div className="text-sm opacity-50">
+				<Link to={`/post/${post.id}`}>
+					{post.nTransitiveComments} {commentString}
+				</Link>{' '}
+				- {post.oSize} {voteString}
+			</div>
+		</div>
+	)
+}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,6 +1,7 @@
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node'
 import { useLoaderData, useParams } from '@remix-run/react'
 import { Markdown } from '#app/components/markdown.tsx'
+import InfoText from '#app/components/ui/info-text.tsx'
 import { db } from '#app/db.ts'
 import { updateHN } from '#app/repositories/hackernews.ts'
 import {
@@ -15,7 +16,6 @@ import {
 } from '#app/types/api-types.ts'
 import { getUserId } from '#app/utils/auth.server.ts'
 import { DiscussionView } from './post.$postId.tsx'
-import InfoText from '#app/components/ui/info-text.tsx'
 
 export async function loader({ request }: LoaderFunctionArgs) {
 	const discussionOfTheDayPostId = await db
@@ -76,7 +76,7 @@ export default function Index() {
 	return (
 		<>
 			<InfoText />
-			<div className="markdown mt-8 mb-4">
+			<div className="markdown mb-4 mt-8">
 				<Markdown deactivateLinks={false}>## Discussion of the Day 🔥</Markdown>
 			</div>
 			<DiscussionView

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,6 +1,5 @@
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node'
 import { useLoaderData, useParams } from '@remix-run/react'
-import { useState } from 'react'
 import { Markdown } from '#app/components/markdown.tsx'
 import { db } from '#app/db.ts'
 import { updateHN } from '#app/repositories/hackernews.ts'
@@ -16,6 +15,7 @@ import {
 } from '#app/types/api-types.ts'
 import { getUserId } from '#app/utils/auth.server.ts'
 import { DiscussionView } from './post.$postId.tsx'
+import InfoText from '#app/components/ui/info-text.tsx'
 
 export async function loader({ request }: LoaderFunctionArgs) {
 	const discussionOfTheDayPostId = await db
@@ -71,38 +71,13 @@ export default function Index() {
 	const { mutableReplyTree, transitiveParents, commentTreeState, loggedIn } =
 		useLoaderData<typeof loader>()
 
-	const [showInfoText, setShowInfoText] = useState(false)
-
 	const params = useParams()
-
-	const titleHeader = "## Today's Discussion"
-
-	const infoText = `
-If you found your way here, it means that you are part of our earliest experiments with users!
-This means that everything that you see here is **highly experimental**.
-We are just learning as we go and we would be eternally grateful for your [feedback](https://forms.gle/dzJtsTJwPSsBihPUA)!
-
-If you want to see more posts, visit our [explore page](/explore).
-	`
-
-	const infoTextClass = showInfoText ? '' : 'hidden'
 
 	return (
 		<>
-			<div className="markdown mb-6 text-sm">
-				<Markdown deactivateLinks={false}>{titleHeader}</Markdown>
-				<div
-					className="cursor-pointer border-l-4 border-solid border-blue-500 pl-2"
-					title="Click to expand"
-					onClick={() => setShowInfoText(!showInfoText)}
-				>
-					<span className="text-blue-500">
-						<Markdown deactivateLinks={false}>🔵 **Info**</Markdown>
-					</span>
-					<div className={infoTextClass}>
-						<Markdown deactivateLinks={false}>{infoText}</Markdown>
-					</div>
-				</div>
+			<InfoText />
+			<div className="markdown mt-8 mb-4">
+				<Markdown deactivateLinks={false}>## Discussion of the Day 🔥</Markdown>
 			</div>
 			<DiscussionView
 				key={params['postId']}

--- a/app/routes/post.$postId.tsx
+++ b/app/routes/post.$postId.tsx
@@ -5,6 +5,7 @@ import { Map } from 'immutable'
 import { useState } from 'react'
 import { z } from 'zod'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
+import InfoText from '#app/components/ui/info-text.tsx'
 import { ParentThread } from '#app/components/ui/parent-thread.tsx'
 import { PostWithReplies } from '#app/components/ui/reply-tree.tsx'
 import { db } from '#app/db.ts'
@@ -25,7 +26,6 @@ import {
 	type ImmutableReplyTree,
 } from '#app/types/api-types.ts'
 import { getUserId } from '#app/utils/auth.server.ts'
-import InfoText from '#app/components/ui/info-text.tsx'
 
 const postIdSchema = z.coerce.number()
 

--- a/app/routes/post.$postId.tsx
+++ b/app/routes/post.$postId.tsx
@@ -25,6 +25,7 @@ import {
 	type ImmutableReplyTree,
 } from '#app/types/api-types.ts'
 import { getUserId } from '#app/utils/auth.server.ts'
+import InfoText from '#app/components/ui/info-text.tsx'
 
 const postIdSchema = z.coerce.number()
 
@@ -66,13 +67,16 @@ export default function PostPage() {
 
 	// subcomponent and key needed for react to not preserve state on page changes
 	return (
-		<DiscussionView
-			key={params['postId']}
-			mutableReplyTree={mutableReplyTree}
-			transitiveParents={transitiveParents}
-			initialCommentTreeState={commentTreeState}
-			loggedIn={loggedIn}
-		/>
+		<>
+			<InfoText className="mb-8" />
+			<DiscussionView
+				key={params['postId']}
+				mutableReplyTree={mutableReplyTree}
+				transitiveParents={transitiveParents}
+				initialCommentTreeState={commentTreeState}
+				loggedIn={loggedIn}
+			/>
+		</>
 	)
 }
 

--- a/app/routes/post.$postId.tsx
+++ b/app/routes/post.$postId.tsx
@@ -66,7 +66,7 @@ export default function PostPage() {
 
 	// subcomponent and key needed for react to not preserve state on page changes
 	return (
-		<Post
+		<DiscussionView
 			key={params['postId']}
 			mutableReplyTree={mutableReplyTree}
 			transitiveParents={transitiveParents}
@@ -76,7 +76,7 @@ export default function PostPage() {
 	)
 }
 
-function Post({
+export function DiscussionView({
 	mutableReplyTree,
 	transitiveParents,
 	initialCommentTreeState,

--- a/app/routes/promoteDiscussionOfTheDay.tsx
+++ b/app/routes/promoteDiscussionOfTheDay.tsx
@@ -1,0 +1,30 @@
+import { redirect, type ActionFunctionArgs } from '@remix-run/node'
+import { z } from 'zod'
+import { db } from '#app/db.ts'
+import { setDiscussionOfTheDay } from '#app/repositories/post.ts'
+import { getUserId } from '#app/utils/auth.server.ts'
+import { invariant } from '#app/utils/misc.tsx'
+
+const discussionOfTheDaySchema = z.object({
+	postId: z.number(),
+})
+
+type DiscussionOfTheDayDTO = {
+	postId: number
+}
+
+export const action = async (args: ActionFunctionArgs) => {
+	let request = args.request
+	const userId = await getUserId(request)
+	invariant(userId, `No authenticated user, got userId ${userId}`)
+
+	const { postId }: DiscussionOfTheDayDTO = discussionOfTheDaySchema.parse(
+		await request.json(),
+	)
+
+	await db
+		.transaction()
+		.execute(async trx => await setDiscussionOfTheDay(trx, postId, userId))
+
+	return redirect(`/post/${postId}`)
+}

--- a/app/types/db-types.ts
+++ b/app/types/db-types.ts
@@ -21,3 +21,4 @@ export type DBVoteEvent = Selectable<schema.VoteEvent>
 export type DBVote = Selectable<schema.Vote>
 export type DBInsertableVoteEvent = Insertable<schema.VoteEvent>
 export type DBHNItem = Selectable<schema.HNItem>
+export type DBDiscussionOfTheDay = Selectable<schema.DiscussionOfTheDay>

--- a/app/types/kysely-types.ts
+++ b/app/types/kysely-types.ts
@@ -137,7 +137,6 @@ export type HNItem = {
 }
 
 export type DiscussionOfTheDay = {
-	id: Generated<number>
 	postId: number
 	promotedAt: number
 }

--- a/app/types/kysely-types.ts
+++ b/app/types/kysely-types.ts
@@ -136,6 +136,12 @@ export type HNItem = {
 	postId: number
 }
 
+export type DiscussionOfTheDay = {
+	id: Generated<number>
+	postId: number
+	promotedAt: number
+}
+
 export type DB = {
 	Vote: Vote
 	Password: Password
@@ -154,4 +160,5 @@ export type DB = {
 	FullScore: FullScore
 	Lineage: Lineage
 	HNItem: HNItem
+	DiscussionOfTheDay: DiscussionOfTheDay
 }

--- a/migrations/2024-07-02-discussion-of-the-day.ts
+++ b/migrations/2024-07-02-discussion-of-the-day.ts
@@ -1,0 +1,13 @@
+import { type Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await db.transaction().execute(async trx => {
+		await sql`
+			create table DiscussionOfTheDay (
+				id integer primary key autoincrement
+				, postId integer not null references Post(id)
+				, promotedAt int not null default (unixepoch('subsec')*1000)
+			)
+		`.execute(trx)
+	})
+}

--- a/migrations/2024-07-02-discussion-of-the-day.ts
+++ b/migrations/2024-07-02-discussion-of-the-day.ts
@@ -4,10 +4,13 @@ export async function up(db: Kysely<any>): Promise<void> {
 	await db.transaction().execute(async trx => {
 		await sql`
 			create table DiscussionOfTheDay (
-				id integer primary key autoincrement
-				, postId integer not null references Post(id)
+				  postId integer not null references Post(id)
 				, promotedAt int not null default (unixepoch('subsec')*1000)
-			)
+			) strict
+		`.execute(trx)
+
+		await sql`
+			create index idx_DiscussionOfTheDay_promotedAt on DiscussionOfTheDay (promotedAt)
 		`.execute(trx)
 	})
 }


### PR DESCRIPTION
- implemented discussion of the day feature
- new admin feature: "Promote" (sets the root of the focussed discussion as discussion of the day)
- explore route for previous frontpage (-> explore new discussions, also with a menu entry in the top right dropdown)
