### PR TITLE
show vote impact instead of post convincingness

### DIFF
--- a/app/components/ui/info-text.tsx
+++ b/app/components/ui/info-text.tsx
@@ -5,8 +5,6 @@ export function InfoText({ className }: { className?: string }) {
 ### Hey, you are part of our early experiments! 🚀
 
 Jabble is a fact-checking platform where everyone can participate.
-Comments are ranked by how convincing they are (🔥), so make sure to provide short, clear, and strong arguments.
-The more you vote on comments, the more impact your vote has on the final score.
 Comments and votes are anonymous to avoid bias.
 
 Everything you see here is a work in progress.

--- a/app/components/ui/post-details.tsx
+++ b/app/components/ui/post-details.tsx
@@ -141,6 +141,7 @@ export function PostDetails({
 					pathFromTargetPost={pathFromTargetPost}
 					postDetailsRef={postDetailsRef}
 					treeContext={treeContext}
+					postState={postState}
 				/>
 			</div>
 

--- a/app/components/ui/post-info-bar.tsx
+++ b/app/components/ui/post-info-bar.tsx
@@ -44,7 +44,7 @@ export function PostInfoBar({
 	return (
 		<>
 			<div className="mb-1 flex w-full flex-wrap items-start gap-2 text-xs">
-				{effectSize > effectSizeThresholds[0] && (
+				{effectSize > effectSizeThresholds[0] && false && (
 					<span title="Convincingness Score. How much this post changed people's opinion on the target post.">
 						<span className="opacity-50">convincing:</span>{' '}
 						{convincingnessScale(effectSize)}


### PR DESCRIPTION
The reply here is "convincing", but before you vote, it is not shown:

![image](https://github.com/user-attachments/assets/a1d7f1cb-691f-4299-8e14-0e16533ef5f5)

Once you vote, it tells you that this vote has high impact (couldn't screenshot it, but if you hover over the flame emoji, it says "Your vote here currently has high impact on the fact-checking result"):

![image](https://github.com/user-attachments/assets/d3245800-b452-410e-9685-eaefd854a96b)